### PR TITLE
Fixed compiler flags in PRDefs overlay

### DIFF
--- a/overlays/n64sdk/ultra/usr/include/make/PRdefs
+++ b/overlays/n64sdk/ultra/usr/include/make/PRdefs
@@ -6,7 +6,7 @@ LIB = $(ROOT)/usr/lib
 LPR = $(LIB)/PR
 INC = $(ROOT)/usr/include
 
-GCCFLAG =       -c -I$(INC) -D_MIPS_SZLONG=34 -D_MIPS_SZINT=32 -D_LANGUAGE_C -D_ULTRA64 -D__EXTENSIONS__ -mabi=32 -march=vr4300 -mtune=vr4300
+GCCFLAG =       -c -I$(INC) -D_MIPS_SZLONG=32 -D_MIPS_SZINT=32 -D_LANGUAGE_C -D_ULTRA64 -D__EXTENSIONS__ -mabi=32 -march=vr4300 -mtune=vr4300
 CFLAGS  =       $(LCDEFS) $(LCINCS) $(LCOPTS) $(GCCFLAG) $(OPTIMIZER)
 
 COMMONRULES     = $(ROOT)/usr/include/make/commonrules


### PR DESCRIPTION
The overlay for PRdefs contains a typo, resulting in an incorrect preprocessor definition for _MIPS_SZLONG.